### PR TITLE
Fix and document skipRoot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ End of yarns
 ```
 $ yarn-recursive --cmd upgrade --opt <package-name>
 ```
+
+### Skip root
+
+If you want to skip the root directory of your project, add the `--skipRoot` option:
+
+```
+$ yarn-recursive --skipRoot --cmd test
+```
+
+This is useful if, for example, you want to run yarn-recursive from a script in your root
+package.json, which would otherwise cause infinite recursion.

--- a/yarn-recursive.js
+++ b/yarn-recursive.js
@@ -34,7 +34,7 @@ function yarn(directoryName) {
 function filterRoot(directoryName) {
   console.log('Root filtering');
 
-  return path.normalize(directoryName) === path.normalize(process.cwd());
+  return path.normalize(directoryName) !== path.normalize(process.cwd());
 }
 
 if (require.main === module) {

--- a/yarn-recursive.js
+++ b/yarn-recursive.js
@@ -21,8 +21,8 @@ function yarn(directoryName) {
     command += ' ' + argv.opt;
 
   console.log(clc.blueBright('Current yarn path: ' + directoryName + '/package.json...'));
- 
-  shell.cd(directoryName);  
+
+  shell.cd(directoryName);
   let result = shell.exec(command);
 
   return {

--- a/yarn-recursive.js
+++ b/yarn-recursive.js
@@ -32,8 +32,6 @@ function yarn(directoryName) {
 }
 
 function filterRoot(directoryName) {
-  console.log('Root filtering');
-
   return path.normalize(directoryName) !== path.normalize(process.cwd());
 }
 


### PR DESCRIPTION
The `--skipRoot` option was broken: instead of excluding the root directory, it excluded all other directories and included _only_ the root directory. This PR inverts the sense of the test to fix that.

There was a `console.log` in the `filterRoot` function, which would print "Root filtering" once for every `package.json` discovered. I don’t think this was the intended behaviour so I’ve removed the log altogether.

The `--skipRoot` option was also undocumented so I’ve added it to the README.