### PR TITLE
Delete useless export

### DIFF
--- a/yarn-recursive.js
+++ b/yarn-recursive.js
@@ -46,7 +46,3 @@ if (require.main === module) {
   console.log(clc.green('End of yarns'));
   process.exit(exitCode);
 }
-
-module.exports = {
-  yarn: yarn
-};


### PR DESCRIPTION
There's no point in exporting the `yarn` function. It can't usefully be called from other modules.