### PR TITLE
Correct license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "install"
   ],
   "author": "Nicolas Rigaudière",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/nrigaudiere/yarn-recursive/issues"
   },


### PR DESCRIPTION
package.json says "ISC", but the actual license in LICENSE is the MIT license.